### PR TITLE
Fix C++20 incompatibilities preventing compilation on MSVC (VS2017)

### DIFF
--- a/dep/g3dlite/source/debugAssert.cpp
+++ b/dep/g3dlite/source/debugAssert.cpp
@@ -103,7 +103,7 @@ static void createErrorMessage(
         if (NULL != formatMsg) {
             realLastErr = formatMsg;
         } else {
-            realLastErr = _T("Last error code does not exist.");
+            realLastErr = (LPTSTR)_T("Last error code does not exist.");
         }
 
         if (lastErr != 0) {

--- a/src/common/Debugging/WheatyExceptionReport.cpp
+++ b/src/common/Debugging/WheatyExceptionReport.cpp
@@ -602,7 +602,7 @@ PEXCEPTION_POINTERS pExceptionInfo)
 // Given an exception code, returns a pointer to a static string with a
 // description of the exception
 //======================================================================
-LPTSTR WheatyExceptionReport::GetExceptionString(DWORD dwCode)
+LPCTSTR WheatyExceptionReport::GetExceptionString(DWORD dwCode)
 {
     #define EXCEPTION(x) case EXCEPTION_##x: return _T(#x);
 

--- a/src/common/Debugging/WheatyExceptionReport.h
+++ b/src/common/Debugging/WheatyExceptionReport.h
@@ -165,7 +165,7 @@ class WheatyExceptionReport
         static BOOL _GetProcessorName(TCHAR* sProcessorName, DWORD maxcount);
 
         // Helper functions
-        static LPTSTR GetExceptionString(DWORD dwCode);
+        static LPCTSTR GetExceptionString(DWORD dwCode);
         static BOOL GetLogicalAddress(PVOID addr, PTSTR szModule, DWORD len,
             DWORD& section, DWORD_PTR& offset);
 

--- a/src/common/Utilities/Types.h
+++ b/src/common/Utilities/Types.h
@@ -34,8 +34,11 @@ namespace Trinity
         using type = find_type_end;
     };
 
+    template<typename T>
+    struct type_identity { using type = T; };
+
     template<template<typename...> typename Check, typename T1, typename... Ts>
-    struct find_type_if<Check, T1, Ts...> : std::conditional_t<Check<T1>::value, std::type_identity<T1>, find_type_if<Check, Ts...>>
+    struct find_type_if<Check, T1, Ts...> : std::conditional_t<Check<T1>::value, type_identity<T1>, find_type_if<Check, Ts...>>
     {
     };
 

--- a/src/server/database/Database/FieldValueConverters.h
+++ b/src/server/database/Database/FieldValueConverters.h
@@ -92,7 +92,7 @@ public:
 };
 
 template<>
-class PrimitiveResultValueConverter<char const*, std::type_identity_t> : public BaseDatabaseResultValueConverter
+class PrimitiveResultValueConverter<char const*, Trinity::type_identity> : public BaseDatabaseResultValueConverter
 {
 public:
     uint8 GetUInt8(char const* /*data*/, uint32 /*size*/, QueryResultFieldMetadata const* meta) const override { LogTruncation("Field::GetUInt8", meta); return 0; }
@@ -109,7 +109,7 @@ public:
     char const* GetCString(char const* data, uint32 /*size*/, QueryResultFieldMetadata const* /*meta*/) const override { return data; }
 };
 
-using StringResultValueConverter = PrimitiveResultValueConverter<char const*, std::type_identity_t>;
+using StringResultValueConverter = PrimitiveResultValueConverter<char const*, Trinity::type_identity>;
 
 class NotImplementedResultValueConverter : public BaseDatabaseResultValueConverter
 {

--- a/src/server/database/Database/MySQLConnection.cpp
+++ b/src/server/database/Database/MySQLConnection.cpp
@@ -452,9 +452,9 @@ void MySQLConnection::StartWorkerThread(Trinity::Asio::IoContext* context)
 {
     boost::asio::executor_work_guard executorWorkGuard = boost::asio::make_work_guard(context->get_executor()); // construct guard before thread starts running
 
-    m_workerThread = std::make_unique<WorkerThread>(WorkerThread{
-        .ThreadHandle = std::thread([context] { context->run(); }),
-        .WorkGuard = std::move(executorWorkGuard)
+     m_workerThread = std::make_unique<WorkerThread>(WorkerThread{
+        std::thread([context] { context->run(); }),
+        std::move(executorWorkGuard)
     });
 }
 

--- a/src/server/database/Database/MySQLPreparedStatement.cpp
+++ b/src/server/database/Database/MySQLPreparedStatement.cpp
@@ -160,17 +160,16 @@ void MySQLPreparedStatement::SetParameter(uint8 index, SystemTimePoint value)
     delete param->length;
     param->length = new unsigned long(len);
 
-    std::chrono::year_month_day ymd(time_point_cast<std::chrono::days>(value));
-    std::chrono::hh_mm_ss hms(duration_cast<std::chrono::microseconds>(value - std::chrono::sys_days(ymd)));
-
+    time_t tt = std::chrono::system_clock::to_time_t(value);
+    tm* t = gmtime(&tt);
     MYSQL_TIME* time = reinterpret_cast<MYSQL_TIME*>(static_cast<char*>(param->buffer));
-    time->year = static_cast<int32>(ymd.year());
-    time->month = static_cast<uint32>(ymd.month());
-    time->day = static_cast<uint32>(ymd.day());
-    time->hour = hms.hours().count();
-    time->minute = hms.minutes().count();
-    time->second = hms.seconds().count();
-    time->second_part = hms.subseconds().count();
+    time->year = t->tm_year + 1900;
+    time->month = t->tm_mon + 1;
+    time->day = t->tm_mday;
+    time->hour = t->tm_hour;
+    time->minute = t->tm_min;
+    time->second = t->tm_sec;
+    time->second_part = 0;
 }
 
 void MySQLPreparedStatement::SetParameter(uint8 index, std::string const& value)

--- a/src/server/database/Database/QueryCallback.cpp
+++ b/src/server/database/Database/QueryCallback.cpp
@@ -93,15 +93,36 @@ bool QueryCallback::InvokeIfReady()
         return false;
     };
 
-    return std::visit([&]<typename Result>(std::future<Result>&& future)
+    struct Visitor
     {
-        if (future.valid() && future.wait_for(0s) == std::future_status::ready)
+        QueryCallback& self;
+        std::function<bool()>& checkStateAndReturnCompletion;
+
+        bool operator()(std::future<QueryResult>&& future)
         {
-            std::future<Result> f(std::move(future));
-            std::function<void(QueryCallback&, Result)> cb(std::get<std::function<void(QueryCallback&, Result)>>(std::move(_callbacks.front())));
-            cb(*this, f.get());
-            return checkStateAndReturnCompletion();
+            if (future.valid() && future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+            {
+                std::future<QueryResult> f(std::move(future));
+                std::function<void(QueryCallback&, QueryResult)> cb(std::get<std::function<void(QueryCallback&, QueryResult)>>(std::move(self._callbacks.front())));
+                cb(self, f.get());
+                return checkStateAndReturnCompletion();
+            }
+            return false;
         }
-        return false;
-    }, std::move(_query));
+
+        bool operator()(std::future<PreparedQueryResult>&& future)
+        {
+            if (future.valid() && future.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+            {
+                std::future<PreparedQueryResult> f(std::move(future));
+                std::function<void(QueryCallback&, PreparedQueryResult)> cb(std::get<std::function<void(QueryCallback&, PreparedQueryResult)>>(std::move(self._callbacks.front())));
+                cb(self, f.get());
+                return checkStateAndReturnCompletion();
+            }
+            return false;
+        }
+    };
+    std::function<bool()> checkFn = checkStateAndReturnCompletion;
+    Visitor v{*this, checkFn};
+    return std::visit(v, std::move(_query));
 }

--- a/src/server/database/Database/QueryResult.cpp
+++ b/src/server/database/Database/QueryResult.cpp
@@ -318,13 +318,26 @@ class DateResultValueConverter : public BaseDatabaseResultValueConverter
         switch (source.time_type)
         {
             case MYSQL_TIMESTAMP_DATE:
-                return sys_days(year(source.year) / month(source.month) / day(source.day));
+            {
+                std::tm t = {};
+                t.tm_year = source.year - 1900;
+                t.tm_mon = source.month - 1;
+                t.tm_mday = source.day;
+                time_t tt = mktime(&t);
+                return std::chrono::system_clock::from_time_t(tt);
+            }
             case MYSQL_TIMESTAMP_DATETIME:
-                return sys_days(year(source.year) / month(source.month) / day(source.day))
-                    + hours(source.hour)
-                    + minutes(source.minute)
-                    + seconds(source.second)
-                    + microseconds(source.second_part);
+            {
+                std::tm t = {};
+                t.tm_year = source.year - 1900;
+                t.tm_mon = source.month - 1;
+                t.tm_mday = source.day;
+                t.tm_hour = source.hour;
+                t.tm_min = source.minute;
+                t.tm_sec = source.second;
+                time_t tt = mktime(&t);
+                return std::chrono::system_clock::from_time_t(tt) + std::chrono::microseconds(source.second_part);
+            }
             default:
                 break;
         }

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -28729,7 +28729,7 @@ void Player::SendGarrisonInfo() const
             {
                 garrisonInfo.Plots.push_back(&plot->PacketInfo);
                 if (plot->BuildingInfo.PacketInfo)
-                    garrisonInfo.Buildings.push_back(std::to_address(plot->BuildingInfo.PacketInfo));
+                    garrisonInfo.Buildings.push_back(plot->BuildingInfo.PacketInfo.has_value() ? &(*plot->BuildingInfo.PacketInfo) : nullptr);
             }
         }
 

--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -520,7 +520,7 @@ void WorldSession::HandlePetRename(WorldPackets::Pet::PetRename& packet)
     ObjectGuid petguid = packet.RenameData.PetGUID;
 
     std::string name = packet.RenameData.NewName;
-    DeclinedName const* declinedname = std::to_address(packet.RenameData.DeclinedNames);
+    DeclinedName const* declinedname = packet.RenameData.DeclinedNames.has_value() ? &(*packet.RenameData.DeclinedNames) : nullptr;
 
     Pet* pet = ObjectAccessor::GetPet(*_player, petguid);
                                                             // check it!

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -4470,10 +4470,10 @@ void Spell::EffectCharge(SpellEffIndex effIndex)
         {
             //unitTarget->GetContactPoint(m_caster, pos.m_positionX, pos.m_positionY, pos.m_positionZ);
             Position pos = unitTarget->GetFirstCollisionPosition(unitTarget->GetObjectSize(), unitTarget->GetRelativeAngle(m_caster));
-            m_caster->GetMotionMaster()->MoveCharge(pos.m_positionX, pos.m_positionY, pos.m_positionZ, speed, EVENT_CHARGE, false, unitTarget, std::to_address(spellEffectExtraData));
+            m_caster->GetMotionMaster()->MoveCharge(pos.m_positionX, pos.m_positionY, pos.m_positionZ, speed, EVENT_CHARGE, false, unitTarget, spellEffectExtraData ? &(*spellEffectExtraData) : nullptr);
         }
         else
-            m_caster->GetMotionMaster()->MoveCharge(*m_preGeneratedPath, speed, unitTarget, std::to_address(spellEffectExtraData));
+            m_caster->GetMotionMaster()->MoveCharge(*m_preGeneratedPath, speed, unitTarget, spellEffectExtraData ? &(*spellEffectExtraData) : nullptr);
     }
 
     if (effectHandleMode == SPELL_EFFECT_HANDLE_HIT_TARGET)

--- a/src/server/scripts/Draenor/Highmaul/boss_the_butcher.cpp
+++ b/src/server/scripts/Draenor/Highmaul/boss_the_butcher.cpp
@@ -16,7 +16,8 @@
  * with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-# include "highmaul.h"
+#include "highmaul.h"
+#include <random>
 
 Position const g_MaggotSpawnPos[eHighmaulDatas::MaxMaggotToKill] =
 {
@@ -400,7 +401,7 @@ class boss_the_butcher : public CreatureScript
                 if (action == eAction::MaggotKilled)
                 {
                     std::vector<uint8> l_Indexes = { 0, 1, 2, 3, 4, 5 };
-                    std::random_shuffle(l_Indexes.begin(), l_Indexes.end());
+                    std::shuffle(l_Indexes.begin(), l_Indexes.end(), std::mt19937{std::random_device{}()});
 
                     for (uint8 l_I : l_Indexes)
                     {

--- a/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
+++ b/src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp
@@ -27,6 +27,8 @@ EndScriptData */
 #include "oculus.h"
 #include "ScriptedCreature.h"
 #include "SpellInfo.h"
+#include "ScriptMgr.h"
+#include <random>
 
 enum Spells
 {
@@ -102,7 +104,7 @@ class boss_urom : public CreatureScript
                 for (uint8 i = 0; i < 3; ++i)
                     group[i] = i;
 
-                std::random_shuffle(group, group + 3);
+                std::shuffle(group, group + 3, std::mt19937{std::random_device{}()});
             }
 
             void Initialize()


### PR DESCRIPTION
**Description:**
The project currently fails to compile on Windows using Visual Studio 2017 (MSVC v141) due to multiple C++20 features being used in a codebase configured for C++17. Below is a detailed list of all the changes required to make the project compile successfully on Windows.

1. dep/g3dlite/source/debugAssert.cpp — Line 106
The assignment to LPTSTR from a string literal fails because the project uses Unicode character set.
```
// Before:
realLastErr = _T("Last error code does not exist.");

// After:
realLastErr = (LPTSTR)_T("Last error code does not exist.");
```

2. src/common/Debugging/WheatyExceptionReport.cpp and WheatyExceptionReport.h
The function GetExceptionString is declared and defined as returning LPTSTR but actually returns const char* literals, causing C2440 errors.
```
// Before (in both .cpp and .h):
LPTSTR GetExceptionString(DWORD dwCode)
LPTSTR WheatyExceptionReport::GetExceptionString(DWORD dwCode)

// After:
LPCTSTR GetExceptionString(DWORD dwCode)
LPCTSTR WheatyExceptionReport::GetExceptionString(DWORD dwCode)
```
Additionally, calls to DumpTypeIndex passing "" as the 7th argument need a cast:
```
// Before:
DumpTypeIndex(..., "");

// After:
DumpTypeIndex(..., (char*)"");
```

3. src/common/Utilities/Types.h
std::type_identity is a C++20 feature not available in C++17. A custom implementation needs to be added.
```
// Before:
struct find_type_if<Check, T1, Ts...> : std::conditional_t<Check<T1>::value, std::type_identity<T1>, find_type_if<Check, Ts...>>

// After — add custom type_identity before the struct:
template<typename T>
struct type_identity { using type = T; };

template<template<typename...> typename Check, typename T1, typename... Ts>
struct find_type_if<Check, T1, Ts...> : std::conditional_t<Check<T1>::value, type_identity<T1>, find_type_if<Check, Ts...>>
```

4. src/server/database/Database/FieldValueConverters.h
std::type_identity_t is C++20. Replace with the custom Trinity::type_identity.
```
// Before:
class PrimitiveResultValueConverter<char const*, std::type_identity_t>
using StringResultValueConverter = PrimitiveResultValueConverter<char const*, std::type_identity_t>;

// After:
class PrimitiveResultValueConverter<char const*, Trinity::type_identity>
using StringResultValueConverter = PrimitiveResultValueConverter<char const*, Trinity::type_identity>;
```

5. src/server/database/Database/QueryCallback.cpp
Template lambdas ([&]<typename T>(...)) are C++20. Replace with a struct Visitor, and the lambda passed as std::function<bool()>& must be stored in a named variable first.
```
// Before:
return std::visit([&]<typename Result>(std::future<Result>&& future)
{
    ...
}, std::move(_query));

// After:
struct Visitor
{
    QueryCallback& self;
    std::function<bool()>& checkStateAndReturnCompletion;

    bool operator()(std::future<QueryResult>&& future) { ... }
    bool operator()(std::future<PreparedQueryResult>&& future) { ... }
};
std::function<bool()> checkFn = checkStateAndReturnCompletion;
Visitor v{*this, checkFn};
return std::visit(v, std::move(_query));
```

6. src/server/database/Database/MySQLPreparedStatement.cpp
std::chrono::year_month_day, hh_mm_ss, and sys_days are C++20. Replace with C++17 compatible code using gmtime.
```
// Before:
std::chrono::year_month_day ymd(time_point_cast<std::chrono::days>(value));
std::chrono::hh_mm_ss hms(duration_cast<std::chrono::microseconds>(value - std::chrono::sys_days(ymd)));
MYSQL_TIME* time = reinterpret_cast<MYSQL_TIME*>(static_cast<char*>(param->buffer));
time->year = static_cast<int32>(ymd.year());
time->month = static_cast<uint32>(ymd.month());
time->day = static_cast<uint32>(ymd.day());
time->hour = hms.hours().count();
time->minute = hms.minutes().count();
time->second = hms.seconds().count();
time->second_part = hms.subseconds().count();

// After:
time_t tt = std::chrono::system_clock::to_time_t(value);
tm* t = gmtime(&tt);
MYSQL_TIME* time = reinterpret_cast<MYSQL_TIME*>(static_cast<char*>(param->buffer));
time->year = t->tm_year + 1900;
time->month = t->tm_mon + 1;
time->day = t->tm_mday;
time->hour = t->tm_hour;
time->minute = t->tm_min;
time->second = t->tm_sec;
time->second_part = 0;
```

7. src/server/database/Database/QueryResult.cpp
Same C++20 date functions (year, month, day, sys_days). Replace with std::tm and mktime.
```
// Before:
case MYSQL_TIMESTAMP_DATE:
    return sys_days(year(source.year) / month(source.month) / day(source.day));
case MYSQL_TIMESTAMP_DATETIME:
    return sys_days(year(source.year) / month(source.month) / day(source.day))
        + hours(source.hour) + minutes(source.minute)
        + seconds(source.second) + microseconds(source.second_part);

// After:
case MYSQL_TIMESTAMP_DATE:
{
    std::tm t = {};
    t.tm_year = source.year - 1900;
    t.tm_mon = source.month - 1;
    t.tm_mday = source.day;
    time_t tt = mktime(&t);
    return std::chrono::system_clock::from_time_t(tt);
}
case MYSQL_TIMESTAMP_DATETIME:
{
    std::tm t = {};
    t.tm_year = source.year - 1900;
    t.tm_mon = source.month - 1;
    t.tm_mday = source.day;
    t.tm_hour = source.hour;
    t.tm_min = source.minute;
    t.tm_sec = source.second;
    time_t tt = mktime(&t);
    return std::chrono::system_clock::from_time_t(tt)
        + std::chrono::microseconds(source.second_part);
}
```

8. src/server/database/Database/MySQLConnection.cpp
Designated initializers ({ .field = value }) are C++20. Replace with direct member assignment. Also, executor_work_guard has a deleted copy assignment operator, so it must be moved using aggregate initialization.
```
// Before:
m_workerThread = std::make_unique<WorkerThread>(WorkerThread{
    .ThreadHandle = std::thread([context] { context->run(); }),
    .WorkGuard = std::move(executorWorkGuard)
});

// After:
m_workerThread = std::make_unique<WorkerThread>(WorkerThread{
    std::thread([context] { context->run(); }),
    std::move(executorWorkGuard)
});
```

9. src/server/game/Entities/Player/Player.cpp — Line 28732
std::to_address is C++20. The field BuildingInfo.PacketInfo is a std::optional, so use has_value() and operator* instead.
```
// Before:
garrisonInfo.Buildings.push_back(std::to_address(plot->BuildingInfo.PacketInfo));

// After:
garrisonInfo.Buildings.push_back(plot->BuildingInfo.PacketInfo.has_value() ? &(*plot->BuildingInfo.PacketInfo) : nullptr);
```

10. src/server/game/Handlers/PetHandler.cpp — Line 523
Same std::to_address issue with std::optional.
```
// Before:
DeclinedName const* declinedname = std::to_address(packet.RenameData.DeclinedNames);

// After:
DeclinedName const* declinedname = packet.RenameData.DeclinedNames.has_value() ? &(*packet.RenameData.DeclinedNames) : nullptr;
```

11. src/server/game/Spells/SpellEffects.cpp — Lines 4473 and 4476
Same std::to_address issue with Optional<Movement::SpellEffectExtraData>.
```
// Before (line 4473):
m_caster->GetMotionMaster()->MoveCharge(..., std::to_address(spellEffectExtraData));

// After:
m_caster->GetMotionMaster()->MoveCharge(..., spellEffectExtraData ? &(*spellEffectExtraData) : nullptr);
```

12. src/server/scripts/Draenor/Highmaul/boss_the_butcher.cpp — Line 403
std::random_shuffle was removed in C++17. Replace with std::shuffle and add #include <random>.
```
// Before:
std::random_shuffle(l_Indexes.begin(), l_Indexes.end());

// After:
#include <random> // add at top of file
std::shuffle(l_Indexes.begin(), l_Indexes.end(), std::mt19937{std::random_device{}()});
```

13. src/server/scripts/Northrend/Nexus/Oculus/boss_urom.cpp — Line 105
Same std::random_shuffle removal. Add #include <random>.
```
// Before:
std::random_shuffle(group, group + 3);

// After:
#include <random> // add at top of file
std::shuffle(group, group + 3, std::mt19937{std::random_device{}()});
```

**Environment:**
- OS: Windows 10/11
- Compiler: MSVC v141 (Visual Studio 2017)
- C++ Standard: /std:c++17 (though some code requires C++20 features)
- Boost: 1.78.0
- MySQL: 8.0
- OpenSSL: 3.x